### PR TITLE
Improved repeated body MIME handling (eg. Apple-Mail)

### DIFF
--- a/email.go
+++ b/email.go
@@ -56,8 +56,10 @@ type Email struct {
 
 // part is a copyable representation of a multipart.Part
 type part struct {
-	header textproto.MIMEHeader
-	body   []byte
+	header    textproto.MIMEHeader
+	body      []byte
+	signature []byte // raw detached signature (only for signed)
+	isSigned  bool   // true if this part came from multipart/signed
 }
 
 // NewEmail creates an Email, and returns the pointer to it.
@@ -152,6 +154,7 @@ func NewEmailFromReader(r io.Reader) (*Email, error) {
 	if err != nil {
 		return e, err
 	}
+	var signedBody []byte // temp buffer for signed content
 	for pIdx, p := range ps {
 		if ct := p.header.Get("Content-Type"); ct == "" {
 			return e, ErrMissingContentType
@@ -160,6 +163,29 @@ func NewEmailFromReader(r io.Reader) (*Email, error) {
 		if err != nil {
 			return e, err
 		}
+
+		// capture signed content into signedBody, but do not assign immediately
+		if p.isSigned {
+			// charset conversion
+			charsetLabel := "utf-8"
+			if x, ok := ctParams["charset"]; ok {
+				charsetLabel = strings.ToLower(x)
+			}
+			content := p.body
+			if charsetLabel != "utf-8" {
+				rc, err := charset.NewReaderLabel(charsetLabel, bytes.NewReader(p.body))
+				if err != nil {
+					return e, fmt.Errorf("failed to convert signed content charset %q: %w", charsetLabel, err)
+				}
+				content, err = io.ReadAll(rc)
+				if err != nil {
+					return e, fmt.Errorf("failed to read signed content: %w", err)
+				}
+			}
+			signedBody = content
+			continue
+		}
+
 		// Check if part is an attachment based on the existence of the Content-Disposition header with a value of "attachment".
 		if cd := p.header.Get("Content-Disposition"); cd != "" {
 			cd, params, err := mime.ParseMediaType(p.header.Get("Content-Disposition"))
@@ -208,12 +234,18 @@ func NewEmailFromReader(r io.Reader) (*Email, error) {
 		}
 
 		switch {
-		case ct == "text/plain":
+		case ct == "text/plain" && len(e.Text) == 0:
 			e.Text = p.body
 		case ct == "text/html":
 			e.HTML = p.body
 		}
 	}
+
+	// fallback: if no Text/HTML but we saw signedBody, use it
+	if len(e.Text) == 0 && len(e.HTML) == 0 && len(signedBody) > 0 {
+		e.Text = signedBody
+	}
+
 	return e, nil
 }
 
@@ -231,7 +263,40 @@ func parseMIMEParts(hs textproto.MIMEHeader, b io.Reader) ([]*part, error) {
 	if err != nil {
 		return ps, err
 	}
-	// If it's a multipart email, recursively parse the parts
+	// Special-case signed parts
+	if ct == "multipart/signed" {
+		mr := multipart.NewReader(b, params["boundary"])
+		// Part1: signed data
+		p1, err := mr.NextPart()
+		if err != nil {
+			return ps, err
+		}
+		// Ensure default Content-Type if missing on signed data part
+		if _, ok := p1.Header["Content-Type"]; !ok {
+			p1.Header.Set("Content-Type", defaultContentType)
+		}
+		var buf1 bytes.Buffer
+		if _, err := io.Copy(&buf1, p1); err != nil {
+			return ps, err
+		}
+		// Part2: signature
+		p2, err := mr.NextPart()
+		if err != nil {
+			return ps, err
+		}
+		var buf2 bytes.Buffer
+		if _, err := io.Copy(&buf2, p2); err != nil {
+			return ps, err
+		}
+		ps = append(ps, &part{
+			body:      buf1.Bytes(),
+			header:    p1.Header,
+			signature: buf2.Bytes(),
+			isSigned:  true,
+		})
+		return ps, nil
+	}
+	// Otherwise recursively parse the parts
 	if strings.HasPrefix(ct, "multipart/") {
 		if _, ok := params["boundary"]; !ok {
 			return ps, ErrMissingBoundary

--- a/email_test.go
+++ b/email_test.go
@@ -523,6 +523,56 @@ d-printable decoding.</div>
 	}
 }
 
+func TestMultipleSameMimeFromReader(t *testing.T) {
+	ex := &Email{
+		Subject: "Test Subject",
+		To:      []string{"Jordan Wright <jmwright798@gmail.com>"},
+		From:    "Jordan Wright <jmwright798@gmail.com>",
+		Text:    []byte("This is a test email with HTML Formatting. It also has very long lines so\nthat the content must be wrapped if using quoted-printable decoding.\n"),
+	}
+	raw := []byte(`
+	MIME-Version: 1.0
+Subject: Test Subject
+From: Jordan Wright <jmwright798@gmail.com>
+To: Jordan Wright <jmwright798@gmail.com>
+Content-Type: multipart/alternative; boundary=001a114fb3fc42fd6b051f834280
+
+--001a114fb3fc42fd6b051f834280
+Content-Type: text/plain; charset=UTF-8
+
+This is a test email with HTML Formatting. It also has very long lines so
+that the content must be wrapped if using quoted-printable decoding.
+
+--001a114fb3fc42fd6b051f834280
+Content-Transfer-Encoding: 7bit
+Content-Type: text/plain;
+	charset=us-ascii
+
+This is second text-plain content-type imitating Apple-Mail legacy compatibility
+functionality that adds the same body also in us-ascii after utf-8 version
+
+--001a114fb3fc42fd6b051f834280--`)
+	e, err := NewEmailFromReader(bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("Error creating email %s", err.Error())
+	}
+	if e.Subject != ex.Subject {
+		t.Fatalf("Incorrect subject. %#q != %#q", e.Subject, ex.Subject)
+	}
+	if !bytes.Equal(e.Text, ex.Text) {
+		t.Fatalf("Incorrect text: %#q != %#q", e.Text, ex.Text)
+	}
+	if e.From != ex.From {
+		t.Fatalf("Incorrect \"From\": %#q != %#q", e.From, ex.From)
+	}
+	if len(e.To) != len(ex.To) {
+		t.Fatalf("Incorrect number of \"To\" addresses: %v != %v", len(e.To), len(ex.To))
+	}
+	if e.To[0] != ex.To[0] {
+		t.Fatalf("Incorrect \"To[0]\": %#q != %#q", e.To[0], ex.To[0])
+	}
+}
+
 func TestNonAsciiEmailFromReader(t *testing.T) {
 	ex := &Email{
 		Subject: "Test Subject",
@@ -883,6 +933,48 @@ Testing!
 	}
 	if !bytes.Equal(e.Text, []byte("Testing!")) {
 		t.Fatalf("Error incorrect text: %#q != %#q\n", e.Text, "Testing!")
+	}
+}
+
+func TestOnlySignedContentType(t *testing.T) {
+	raw := []byte(`From: Mikhail Gusarov <dottedmag@dottedmag.net>
+To: notmuch@notmuchmail.org
+References: <20091117190054.GU3165@dottiness.seas.harvard.edu>
+Date: Wed, 18 Nov 2009 01:02:38 +0600
+Message-ID: <87iqd9rn3l.fsf@vertex.dottedmag>
+MIME-Version: 1.0
+Subject: Re: [notmuch] Working with Maildir storage?
+Content-Type: multipart/mixed; boundary="===============1958295626=="
+
+--===============1958295626==
+Content-Type: multipart/signed; boundary="=-=-=";
+    micalg=pgp-sha1; protocol="application/pgp-signature"
+
+--=-=-=
+Content-Transfer-Encoding: quoted-printable
+
+Twas brillig at 14:00:54 17.11.2009 UTC-05 when lars@seas.harvard.edu did g=
+yre and gimble:
+
+--=-=-=
+Content-Type: application/pgp-signature
+
+-----BEGIN PGP SIGNATURE-----
+Version: GnuPG v1.4.9 (GNU/Linux)
+
+iQIcBAEBAgAGBQJLAvNOAAoJEJ0g9lA+M4iIjLYQAKp0PXEgl3JMOEBisH52AsIK
+=/ksP
+-----END PGP SIGNATURE-----
+--=-=-=--
+
+--===============1958295626==--
+`)
+	e, err := NewEmailFromReader(bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("Error when parsing email %s", err.Error())
+	}
+	if !bytes.Equal(e.Text, []byte("Twas brillig at 14:00:54 17.11.2009 UTC-05 when lars@seas.harvard.edu did gyre and gimble:\n")) {
+		t.Fatalf("Error incorrect text: %#q != %#q\n", e.Text, "Twas brillig at 14:00:54 17.11.2009 UTC-05 when lars@seas.harvard.edu did gyre and gimble:\n")
 	}
 }
 


### PR DESCRIPTION
Adds support in `NewEmailFromReader` for messages that have multiple MIME parts that can be handled at `text/plain` body. Where previously the LAST such MIME was always used, the current change switches this to always using the FIRST such MIME which should align more closely to real world implementations.

This comes up eg. with Apple Mail which emits a second MIME part with US-ASCII/7bit as a legacy fallback section. In the old implementation that would always get used instead of the utf-8 one.

Additionally  - the previous implementation used the above mentioned "use last body MIME" logic to better handle messages with a `Content-Type: multipart/signed`. It used the signed content as body if there is no other body found in the message. The new code does the same. While it overall switched to using the first defined body - if none are found but there is signed content, then this signed content is used as body.

No signature verification or other `multipart/signed` handling was added as it was out of scope and a larger change.